### PR TITLE
avoid loading attribute if not exists in psutil.Process

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -45,12 +45,11 @@ def _get_memory(pid, timestamps=False, include_children=False):
     if has_psutil:
         process = psutil.Process(pid)
         try:
-            mem_info = getattr(process, 'memory_info', process.get_memory_info)
-            mem = mem_info()[0] / _TWO_20
+            meminfo_attr = 'memory_info' if hasattr(process, 'memory_info') else 'get_memory_info'
+            mem = getattr(process, meminfo_attr)()[0] / _TWO_20
             if include_children:
                 for p in process.get_children(recursive=True):
-                    mem_info = getattr(p, 'memory_info', p.get_memory_info)
-                    mem += mem_info()[0] / _TWO_20
+                    mem += getattr(process, meminfo_attr)()[0] / _TWO_20
             if timestamps:
                 return (mem, time.time())
             else:


### PR DESCRIPTION
The `default` of `getattr` will be accessed anyway, so avoid use it since get_memory_info is not exists in psutil > 2.0 and accessing it will cause exception.