### PR TITLE
Warn about memory_profiler/mprof interplay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,8 @@ afterward will plot the result, making plots (using matplotlib) similar to these
 
 A discussion of these capabilities can be found `here <http://fa.bianp.net/blog/2014/plot-memory-usage-as-a-function-of-time/>`_.
 
+.. warning:: If your Python file imports the memory profiler `from memory_profiler import profile` these timestamps will not be recorded. Comment out the import, leave your functions decorated, and re-run.
+
 The available commands for `mprof` are: 
 
   - ``mprof run``: running an executable, recording memory usage  


### PR DESCRIPTION
This took me time to track down - running memory_profiler in a script run via mprof will prevent the function timings being recorded & plotted on the graph.