### PR TITLE
Refactor lineprofiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 dist
 build
-*.pyc
 MANIFEST
+*.egg-info
+*.pyc
 *~

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test:
 	$(PYTHON) -m memory_profiler test/test_as.py
 	$(PYTHON) -m memory_profiler test/test_global.py
 	$(PYTHON) -m memory_profiler test/test_precision_command_line.py
+	$(PYTHON) -m memory_profiler test/test_gen.py
 	$(PYTHON) test/test_import.py
 	$(PYTHON) test/test_memory_usage.py
 	$(PYTHON) test/test_precision_import.py

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -1,0 +1,41 @@
+
+@profile
+def test_comprehension():
+    # Dict comprehension
+    d_comp = {str(k*k): [v] * (1<<17)
+              for (v, k) in enumerate(range(99, 111))}
+
+    # List comprehension
+    l_comp = [[i] * (i<<9) for i in range(99)]
+    del l_comp
+    del d_comp
+
+    def hh(x=1):
+        # Set comprehension
+        s_comp = {('Z',) * (k<<13) for k in range(x, 19 + 2*x)}
+        return s_comp
+
+    val = [range(1, 4), max(1, 4), 42 + len(hh())]
+    val = hh() | hh(4)
+    val.add(40)
+    l1_comp = [[(1, i)] * (i<<9) for i in range(99)]
+    l2_comp = [[(3, i)] * (i<<9) for i in range(99)]
+
+    return val
+
+
+@profile
+def test_generator():
+    a_gen = ([42] * (1<<20) for __ in '123')
+    huge_lst = list(a_gen)
+
+    b_gen = ([24] * (1<<20) for __ in '123')
+    del b_gen
+    del huge_lst
+
+    return a_gen
+
+
+if __name__ == '__main__':
+    test_generator()
+    test_comprehension()

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -1,5 +1,13 @@
 
 @profile
+def my_func():
+    a = [1] * (10 ** 6)
+    b = [2] * (2 * 10 ** 7)
+    del b
+    yield a
+
+
+@profile
 def test_comprehension():
     # Dict comprehension
     d_comp = {str(k*k): [v] * (1<<17)
@@ -37,5 +45,8 @@ def test_generator():
 
 
 if __name__ == '__main__':
+    with profile:
+        next(my_func())     # Issue #42
+
     test_generator()
     test_comprehension()


### PR DESCRIPTION
I did some changes on the line profiler logic to support more syntaxes:
* generator expression (issue #42) 
* list comprehension
* set and dict comprehensions
* lines with Python function calls

There are 4 commits:
1. git-ignore `*.egg-info` directory
2. clean-up/review unrelated syntax, and fix typo
3. enhance the logic to compute memory for the above use cases, with examples `test/test_gen.py` 
4. add specific test for issue #42