### PR TITLE
Allow %memit to return a result object and to be quiet 

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -63,11 +63,13 @@ class MemitResult(object):
         self.interval = interval
         self.include_children = include_children
 
-    def _repr_pretty_(self, p , cycle):
+    def __str__(self):
         max_mem = max(self.mem_usage)
         inc = max_mem - self.baseline
-        msg = 'peak memory: %.02f MiB, increment: %.02f MiB' % (max_mem, inc)
+        return 'peak memory: %.02f MiB, increment: %.02f MiB' % (max_mem, inc)
 
+    def _repr_pretty_(self, p , cycle):
+        msg = str(self)
         p.text(u'<MemitResult : '+msg+u'>')
 
 
@@ -873,18 +875,18 @@ class MemoryProfilerMagics(Magics):
                                include_children=include_children)
             mem_usage.append(tmp[0])
 
+        result = MemitResult(mem_usage, baseline, repeat, timeout, interval,
+                             include_children)
+
         if not quiet:
             if mem_usage:
-                max_mem = max(mem_usage)
-                print('peak memory: %.02f MiB, increment: %.02f MiB' %
-                      (max_mem, max_mem - baseline))
+                print(result)
             else:
                 print('ERROR: could not read memory usage, try with a lower interval '
                       'or more iterations')
 
         if return_result:
-            return MemitResult(mem_usage, baseline, repeat, timeout, interval,
-                               include_children)
+            return result
 
     @classmethod
     def register_magics(cls, ip):

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -817,6 +817,9 @@ class MemoryProfilerMagics(Magics):
         -c: If present, add the memory usage of any children process to the report.
 
         -o: If present, return a object containing memit run details
+
+        -q: If present, be quiet and do not output a result.
+
         Examples
         --------
         ::
@@ -834,7 +837,7 @@ class MemoryProfilerMagics(Magics):
 
         """
         from memory_profiler import memory_usage, _func_exec
-        opts, stmt = self.parse_options(line, 'r:t:i:co', posix=False, strict=False)
+        opts, stmt = self.parse_options(line, 'r:t:i:coq', posix=False, strict=False)
 
         if cell is None:
             setup = 'pass'
@@ -851,6 +854,7 @@ class MemoryProfilerMagics(Magics):
         interval = float(getattr(opts, 'i', 0.1))
         include_children = 'c' in opts
         return_result = 'o' in opts
+        quiet = 'q' in opts
 
         # I've noticed we get less noisier measurements if we run
         # a garbage collection first
@@ -869,13 +873,14 @@ class MemoryProfilerMagics(Magics):
                                include_children=include_children)
             mem_usage.append(tmp[0])
 
-        if mem_usage:
-            max_mem = max(mem_usage)
-            print('peak memory: %.02f MiB, increment: %.02f MiB' %
-                  (max_mem, max_mem - baseline))
-        else:
-            print('ERROR: could not read memory usage, try with a lower interval '
-                  'or more iterations')
+        if not quiet:
+            if mem_usage:
+                max_mem = max(mem_usage)
+                print('peak memory: %.02f MiB, increment: %.02f MiB' %
+                      (max_mem, max_mem - baseline))
+            else:
+                print('ERROR: could not read memory usage, try with a lower interval '
+                      'or more iterations')
 
         if return_result:
             return MemitResult(mem_usage, baseline, repeat, timeout, interval,


### PR DESCRIPTION
An example of its use is below. The object and implementation were adapted from IPython's `timeit` returnable.

```python
> %load_ext memory_profiler

> %memit -r 10 1+2
peak memory: 25.06 MiB, increment: 0.15 MiB

> result = %memit -o -r 10 1+2
peak memory: 24.10 MiB, increment: 0.01 MiB

> result
Out[4]: <MemitResult : peak memory: 24.10 MiB, increment: 0.01 MiB>

> result.mem_usage
Out[5]:
[24.0859375,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625,
 24.09765625]
```