### PR TITLE
ENH added optional ``tracemalloc`` backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ test:
 	$(PYTHON) -m memory_profiler test/test_precision_command_line.py
 	$(PYTHON) -m memory_profiler test/test_gen.py
 	$(PYTHON) -m memory_profiler test/test_unicode.py
+	$(PYTHON) test/test_tracemalloc.py
 	$(PYTHON) test/test_import.py
 	$(PYTHON) test/test_memory_usage.py
 	$(PYTHON) test/test_precision_import.py
 	$(IPYTHON) test/test_ipython.py
+

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -17,7 +17,6 @@ import inspect
 import subprocess
 import logging
 
-from collections import OrderedDict
 
 # TODO: provide alternative when multiprocessing is not available
 try:
@@ -1012,26 +1011,18 @@ def choose_backend(new_backend=None):
     setup one of the allowable backends
     """
 
-    backends = OrderedDict([
+    backends = [
         ('psutil', has_psutil),
         ('posix', os.name == 'posix'),
         ('tracemalloc', has_tracemalloc),
         ('no_backend', True)
-    ])
+    ]
+    backends_indices = {b[0]: i for i, b in enumerate(backends)}
 
-    def move_to_start(d, key):
-        """
-        Emulation of OrderedDict.move_to_end(last=False) for old versions of Python
-        """
-        items = [(key, d[key])]
-        for _key, _value in d.items():
-            if _key != key:
-                items.append((_key, _value))
-        return OrderedDict(items)
     if new_backend is not None:
-        backends = move_to_start(backends, new_backend)
+        backends.insert(0, backends.pop(backends_indices[new_backend]))
 
-    for n_backend, is_available in backends.items():
+    for n_backend, is_available in backends:
         if is_available:
             global _backend
             _backend = n_backend

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -187,7 +187,6 @@ class MemTimer(Process):
         self.include_children = kw.pop("include_children", False)
 
         # get baseline memory usage
-        # TODO: add filename
         self.mem_usage = [
             _get_memory(self.monitor_pid, timestamps=self.timestamps,
                         include_children=self.include_children)]
@@ -197,7 +196,6 @@ class MemTimer(Process):
         self.pipe.send(0)  # we're ready
         stop = False
         while True:
-            # TODO: add filename
             cur_mem = _get_memory(self.monitor_pid, timestamps=self.timestamps,
                                   include_children=self.include_children)
             if not self.max_usage:
@@ -316,7 +314,6 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
         line_count = 0
         while True:
             if not max_usage:
-                # TODO: add filename
                 mem_usage = _get_memory(proc.pid, timestamps=timestamps,
                                         include_children=include_children)
                 if stream is not None:
@@ -324,7 +321,6 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
                 else:
                     ret.append(mem_usage)
             else:
-                # TODO: add filename
                 ret = max(ret,
                           _get_memory(proc.pid,
                                       include_children=include_children))
@@ -349,7 +345,6 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
         while counter < max_iter:
             counter += 1
             if not max_usage:
-                # TODO: add filename
                 mem_usage = _get_memory(proc, timestamps=timestamps,
                                         include_children=include_children)
                 if stream is not None:
@@ -357,7 +352,6 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
                 else:
                     ret.append(mem_usage)
             else:
-                # TODO: add filename
                 ret = max([ret,
                            _get_memory(proc, include_children=include_children)
                            ])

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1048,7 +1048,7 @@ def choose_backend(new_backend=None):
             'Tracemalloc or psutil module is required for non-unix '
             'platforms')
     if _backend != new_backend and new_backend is not None:
-        print('{} can not be used, {} used instead'.format(new_backend,
+        print('{0} can not be used, {1} used instead'.format(new_backend,
                                                            _backend))
     global _backend_chosen
     _backend_chosen = True

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -995,7 +995,19 @@ def choose_backend():
         ('tracemalloc', has_tracemalloc),
         ('no_backend', True)
     ])
-    backends.move_to_end(_backend, last=False)
+
+    def move_to_start(d, key):
+        """
+        Emulation of OrderedDict.move_to_end(last=False) for old versions of Python
+        """
+        items = [(key, d[key])]
+        for _key, _value in d.items():
+            if _key != key:
+                items.append((_key, _value))
+        return OrderedDict(items)
+
+    backends = move_to_start(backends, _backend)
+
     for n_backend, is_available in backends.items():
         if is_available:
             _backend = n_backend

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -262,7 +262,7 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
     ret : return value of the profiled function
         Only returned if retval is set to True
     """
-    if not _backend_chosen:
+    if _backend is None:
         choose_backend()
     if stream is not None:
         timestamps = True
@@ -952,9 +952,8 @@ class MemoryProfilerMagics(Magics):
             if mem_usage:
                 print(result)
             else:
-                print(
-                    'ERROR: could not read memory usage, try with a lower interval '
-                    'or more iterations')
+                print('ERROR: could not read memory usage, try with a '
+                      'lower interval or more iterations')
 
         if return_result:
             return result
@@ -1050,8 +1049,6 @@ def choose_backend(new_backend=None):
     if _backend != new_backend and new_backend is not None:
         print('{0} can not be used, {1} used instead'.format(new_backend,
                                                            _backend))
-    global _backend_chosen
-    _backend_chosen = True
 
 
 # Insert in the built-ins to have profile

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1031,7 +1031,7 @@ else:
             with open(filename) as f:
                 exec(compile(f.read(), filename, 'exec'), ns, ns)
         finally:
-            if tracemalloc.is_tracing():
+            if has_tracemalloc and tracemalloc.is_tracing():
                 tracemalloc.stop()
 
 

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -253,6 +253,8 @@ def memory_usage(proc=-1, interval=.1, timeout=None, timestamps=False,
     ret : return value of the profiled function
         Only returned if retval is set to True
     """
+    if not _backend_chosen:
+        choose_backend()
     if stream is not None:
         timestamps = True
 

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -966,8 +966,8 @@ def profile(func=None, stream=None, precision=1, backend='psutil'):
     Decorator that will run the function and print a line-by-line profile
     """
     global _backend
-    _backend = backend
     if not _backend_chosen:
+        _backend = backend
         choose_backend()
     if _backend == 'tracemalloc' and not tracemalloc.is_tracing():
         tracemalloc.start()

--- a/mprof
+++ b/mprof
@@ -27,11 +27,11 @@ Type mprof <command> --help for usage help on a specific command.
 For example, mprof plot --help will list all plotting options.
 """
 
+
 def print_usage():
     print("Usage: %s <command> <options> <arguments>"
-                  % osp.basename(sys.argv[0]))
+          % osp.basename(sys.argv[0]))
     print(help_msg)
-
 
 
 def get_action():
@@ -233,7 +233,7 @@ def run_action():
     with open(mprofile_output, "a") as f:
         f.write("CMDLINE {0}\n".format(cmd_line))
         mp.memory_usage(proc=p, interval=options.interval, timestamps=True,
-                         include_children=options.include_children, stream=f)
+                        include_children=options.include_children, stream=f)
 
 
 def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
@@ -257,7 +257,7 @@ def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
         sys.exit(1)
     height_ratio = 20.
     vsize = (pl.ylim()[1] - pl.ylim()[0]) / height_ratio
-    hsize = (pl.xlim()[1] - pl.xlim()[0]) / (3.*height_ratio)
+    hsize = (pl.xlim()[1] - pl.xlim()[0]) / (3. * height_ratio)
 
     bracket_x = pl.asarray([hsize, 0, 0, hsize])
     bracket_y = pl.asarray([vsize, vsize, -vsize, -vsize])
@@ -270,16 +270,16 @@ def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
                 "-" + color, linewidth=2, label=label)
     if options.xlim is None or options.xlim[0] <= (xloc[1] - xshift) <= options.xlim[1]:
         pl.plot(-bracket_x + xloc[1] - xshift, bracket_y + yloc[1],
-                "-" + color, linewidth=2 )
+                "-" + color, linewidth=2)
 
-    # TODO: use matplotlib.patches.Polygon to draw a colored background for
-    # each function.
+        # TODO: use matplotlib.patches.Polygon to draw a colored background for
+        # each function.
 
-    # with maplotlib 1.2, use matplotlib.path.Path to create proper markers
-    # see http://matplotlib.org/examples/pylab_examples/marker_path.html
-    # This works with matplotlib 0.99.1
-    ## pl.plot(xloc[0], yloc[0], "<"+color, markersize=7, label=label)
-    ## pl.plot(xloc[1], yloc[1], ">"+color, markersize=7)
+        # with maplotlib 1.2, use matplotlib.path.Path to create proper markers
+        # see http://matplotlib.org/examples/pylab_examples/marker_path.html
+        # This works with matplotlib 0.99.1
+        ## pl.plot(xloc[0], yloc[0], "<"+color, markersize=7, label=label)
+        ## pl.plot(xloc[1], yloc[1], ">"+color, markersize=7)
 
 
 def read_mprofile_file(filename):
@@ -331,7 +331,6 @@ def read_mprofile_file(filename):
             'cmd_line': cmd_line}
 
 
-
 def plot_file(filename, index=0, timestamps=True, options=None):
     try:
         import pylab as pl
@@ -346,7 +345,7 @@ def plot_file(filename, index=0, timestamps=True, options=None):
               'file.**\nFile path: {0}\n'
               'File may be empty or invalid.\n'
               'It can be deleted with "mprof rm {0}"'.format(
-              mprofile['filename']))
+            mprofile['filename']))
         sys.exit(0)
 
     # Merge function timestamps and memory usage together
@@ -373,11 +372,11 @@ def plot_file(filename, index=0, timestamps=True, options=None):
     max_mem = mem.max()
     max_mem_ind = mem.argmax()
 
-    all_colors=("c", "y", "g", "r", "b")
-    mem_line_colors=("k", "b", "r", "g", "c", "y", "m")
+    all_colors = ("c", "y", "g", "r", "b")
+    mem_line_colors = ("k", "b", "r", "g", "c", "y", "m")
     mem_line_label = time.strftime("%d / %m / %Y - start at %H:%M:%S",
                                    time.localtime(global_start)) \
-                                   + ".{0:03d}".format(int(round(math.modf(global_start)[0]*1000)))
+                     + ".{0:03d}".format(int(round(math.modf(global_start)[0] * 1000)))
 
     pl.plot(t, mem, "+-" + mem_line_colors[index % len(mem_line_colors)],
             label=mem_line_label)
@@ -392,9 +391,9 @@ def plot_file(filename, index=0, timestamps=True, options=None):
         for f, exec_ts in ts.items():
             for execution in exec_ts:
                 add_brackets(execution[:2], execution[2:], xshift=global_start,
-                             color= all_colors[func_num % len(all_colors)],
+                             color=all_colors[func_num % len(all_colors)],
                              label=f.split(".")[-1]
-                             + " %.3fs" % (execution[1] - execution[0]), options=options)
+                                   + " %.3fs" % (execution[1] - execution[0]), options=options)
             func_num += 1
 
     if timestamps:
@@ -495,6 +494,7 @@ def plot_action():
         pl.savefig(options.output)
     else:
         pl.show()
+
 
 if __name__ == "__main__":
     # Workaround for optparse limitation: insert -- before first negative

--- a/test/test_tracemalloc.py
+++ b/test/test_tracemalloc.py
@@ -1,0 +1,47 @@
+import pytest
+import tracemalloc
+from io import StringIO
+from time import sleep
+
+from memory_profiler import profile
+import memory_profiler
+
+tracemalloc.start()
+output = StringIO()
+
+# allowable error in MB
+EPSILON = 0.0001
+
+memory_profiler._backend = 'tracemalloc'
+
+
+@pytest.mark.parametrize('test_input,expected', [
+    (100, 0.00012302398681640625),
+    (1000, 0.0009813308715820312),
+    (10000, 0.009564399719238281),
+    (100000, 0.09539508819580078),
+    (1000000, 0.9537019729614258),
+    (10000000, 9.536770820617676),
+    (100000000, 95.36745929718018),
+])
+def test_memory_profiler(test_input, expected):
+    mem_prof(test_input)
+    inc, dec = parse_mem_prof()
+    assert abs(inc - dec) <= EPSILON, 'inc = {}, dec = {}, err = {}'.format(inc, dec, abs(inc - dec))
+    assert abs(inc - expected) <= EPSILON, 'inc = {}, size = {}, err = {}'.format(inc, expected, abs(inc - expected))
+
+
+@profile(stream=output, precision=6)
+def mem_prof(n):
+    a = bytearray(n)
+    del a
+    sleep(1)
+
+
+def parse_mem_prof():
+    text = output.getvalue().split('\n')
+
+    def f(s):
+        return float(s.split()[3])
+
+    return f(text[-6]), -f(text[-5])

--- a/test/test_tracemalloc.py
+++ b/test/test_tracemalloc.py
@@ -18,8 +18,12 @@ EPSILON = 0.0001
 def test_memory_profiler(test_input, expected):
     mem_prof(test_input)
     inc, dec = parse_mem_prof()
-    assert abs(inc - dec) <= EPSILON, 'inc = {}, dec = {}, err = {}'.format(inc, dec, abs(inc - dec))
-    assert abs(inc - expected) <= EPSILON, 'inc = {}, size = {}, err = {}'.format(inc, expected, abs(inc - expected))
+    assert abs(inc - dec) <= EPSILON, \
+        'inc = {}, dec = {}, err = {}'.format(inc, dec, abs(inc - dec))
+    assert abs(inc - expected) <= EPSILON, \
+        'inc = {}, size = {}, err = {}'.format(
+            inc, expected, abs(inc - expected)
+        )
 
 
 @profile(stream=output, precision=6, backend='tracemalloc')

--- a/test/test_tracemalloc.py
+++ b/test/test_tracemalloc.py
@@ -1,29 +1,20 @@
-import pytest
-import tracemalloc
 from io import StringIO
 from time import sleep
 
 from memory_profiler import profile
-import memory_profiler
 
-tracemalloc.start()
+try:
+    import tracemalloc
+    has_tracemalloc = True
+except ImportError:
+    has_tracemalloc = False
+
 output = StringIO()
 
 # allowable error in MB
 EPSILON = 0.0001
 
-memory_profiler._backend = 'tracemalloc'
 
-
-@pytest.mark.parametrize('test_input,expected', [
-    (100, 0.00012302398681640625),
-    (1000, 0.0009813308715820312),
-    (10000, 0.009564399719238281),
-    (100000, 0.09539508819580078),
-    (1000000, 0.9537019729614258),
-    (10000000, 9.536770820617676),
-    (100000000, 95.36745929718018),
-])
 def test_memory_profiler(test_input, expected):
     mem_prof(test_input)
     inc, dec = parse_mem_prof()
@@ -31,7 +22,7 @@ def test_memory_profiler(test_input, expected):
     assert abs(inc - expected) <= EPSILON, 'inc = {}, size = {}, err = {}'.format(inc, expected, abs(inc - expected))
 
 
-@profile(stream=output, precision=6)
+@profile(stream=output, precision=6, backend='tracemalloc')
 def mem_prof(n):
     a = bytearray(n)
     del a
@@ -45,3 +36,17 @@ def parse_mem_prof():
         return float(s.split()[3])
 
     return f(text[-6]), -f(text[-5])
+
+if __name__ == '__main__':
+    if has_tracemalloc:
+        tests = [
+            (100, 0.00012302398681640625),
+            (1000, 0.0009813308715820312),
+            (10000, 0.009564399719238281),
+            (100000, 0.09539508819580078),
+            (1000000, 0.9537019729614258),
+            (10000000, 9.536770820617676),
+            (100000000, 95.36745929718018),
+        ]
+        for test_input, expected in tests:
+            test_memory_profiler(test_input, expected)


### PR DESCRIPTION
It is now possible to use ``tracemalloc`` to analyze memory usage Python
code on Python 3.4 and above. ``tracemalloc`` allows for more precise
measurements compared to ``psutil``. However, it only works either for
pure Python code or for C extensions allocating memory via ``PyMem_Alloc``.

To use the new backend code run ``memory_profiler`` with ``--backend``
option, e.g.

    $ python -m memory_profiler --backend=tracemalloc script.py

Also if you use ``memory_profiler`` with imported decorator you can specify
backend as an argument to the decorator function:

    @profile(backend='tracemalloc')
    def f(n):
        a = [0] * n
        return a

``backend`` parameter to ``@profile`` has priority over ``--backend``.

Note that using ``tracemalloc`` in ``mprof`` and IPython magic is not
supported at the moment.