### PR TITLE
More user friendly error message

### DIFF
--- a/mprof
+++ b/mprof
@@ -252,8 +252,9 @@ def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
     """
     try:
         import pylab as pl
-    except ImportError:
-        print("matplotlib is needed for plotting and tkinter for visualisation.")
+    except ImportError as e:
+        print("matplotlib is needed for plotting.")
+        print(e)
         sys.exit(1)
     height_ratio = 20.
     vsize = (pl.ylim()[1] - pl.ylim()[0]) / height_ratio

--- a/mprof
+++ b/mprof
@@ -253,7 +253,7 @@ def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
     try:
         import pylab as pl
     except ImportError:
-        print("matplotlib is needed for plotting.")
+        print("matplotlib is needed for plotting and tkinter for visualisation.")
         sys.exit(1)
     height_ratio = 20.
     vsize = (pl.ylim()[1] - pl.ylim()[0]) / height_ratio


### PR DESCRIPTION
This is helpful as if tkinter is not installed the ImportError is caught
here and although the user has installed matplotlib the error message
says matplotlib is needed.
So this small change fixes this.
Could have something to do with https://github.com/fabianp/memory_profiler/issues/91