### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include COPYING


### PR DESCRIPTION
Include the license file in packages (e.g. `sdist`s) by adding it to the `MANIFEST.in`.