### PR TITLE
Makes the mprof executable use `sys.executable` instead of "python" for subprocess

### DIFF
--- a/mprof
+++ b/mprof
@@ -218,11 +218,12 @@ def run_action():
         options.python = True
     if options.python:
         print("running as a Python program...")
-        if not args[0].startswith("python"):
-            args.insert(0, "python")
+        if not osp.basename(args[0]).startswith("python"):
+            args.insert(0, sys.executable)
         cmd_line = get_cmd_line(args)
         args[1:1] = ("-m", "memory_profiler", "--timestamp",
                      "-o", mprofile_output)
+        #print(" ".join(args))
         p = subprocess.Popen(args)
     else:
         cmd_line = get_cmd_line(args)


### PR DESCRIPTION
When `mprof run` starts a subprocess, it now uses `sys.executable` as the python interpreter instead of the string python.

This is useful so the user can run mprof with a python version that is not in the first hit in the current PATH.