### PR TITLE
Improve child handling

### DIFF
--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1215,7 +1215,7 @@ def read_mprofile_file(filename):
     """Read an mprofile file and return its content.
 
     Returns
-    =======
+    -------
     content: dict
         Keys:
 
@@ -1272,7 +1272,7 @@ def read_mprofile_file_multiprocess(filename):
     """Read an mprofile file and return a mem_usage list
 
     Returns
-    =======
+    -------
     content: list
 
     This is analogous to the list obtained when the `memory_usage` is used
@@ -1304,8 +1304,17 @@ def read_mprofile_file_multiprocess(filename):
 def convert_mem_usage_to_df(filename, is_pickle=False): 
     """Convert a `mem_usage` list to a `pandas.DataFrame`
 
+    Parameters
+    ----------
+    filename: path to the memory profile data; can be either a file
+        created by mprof or a pickle of the result of `memory_usage`
+
+    is_pickle: if True, assume the data is the pickled list 
+        returned by `memory_usage`
+
+    
     Returns
-    =======
+    -------
     content: pandas.DataFrame
 
     Returns a `pandas.DataFrame` with child IDs as columns and the timestamp as an index

--- a/memory_profiler.py
+++ b/memory_profiler.py
@@ -1346,4 +1346,5 @@ def convert_mem_usage_to_df(filename, is_pickle=False):
                 data[time_lookup[t]][pid_lookup[pid]] = mem
         except TypeError:
             print 'found a bad value in ', i
+            
     return pd.DataFrame(data, index=times, columns=pids)

--- a/mprof
+++ b/mprof
@@ -201,14 +201,14 @@ def run_action():
                       help="""Monitors forked processes creating individual plots for each child""")
     parser.add_option("--pid", "-p", dest="pid",
                       default=False, action="store_true", 
-                      help="""Monitor an existing process given by PID""")
+                      help="""Specify that the argument is a running pid not an executable or script""")
     parser.add_option("--timeout", dest="timeout", 
                       default=None, action="store", type=int,
                       help="""Timeout in seconds""")
 
     (options, args) = parser.parse_args()
 
-    if (len(args) == 0) and not options.pid:
+    if (len(args) == 0):
         print("A program to run or a pid must be provided. Use -h for help")
         sys.exit(1)
 

--- a/mprof
+++ b/mprof
@@ -370,7 +370,6 @@ def plot_file(filename, index=0, timestamps=True, children=True, options=None):
             cmem = np.asarray([item[0] for item in data])
 
             # Plot the line to the figure
-            print (idx+1) % len(mem_line_colors)
             pl.plot(cts, cmem, "+-"  + mem_line_colors[(idx+1) % len(mem_line_colors)],
                      label="child {}".format(proc))
 

--- a/mprof
+++ b/mprof
@@ -199,11 +199,17 @@ def run_action():
     parser.add_option("--multiprocess", "-M", dest="multiprocess",
                       default=False, action="store_true",
                       help="""Monitors forked processes creating individual plots for each child""")
+    parser.add_option("--pid", "-p", dest="pid",
+                      default=False, action="store_true", 
+                      help="""Monitor an existing process given by PID""")
+    parser.add_option("--timeout", dest="timeout", 
+                      default=None, action="store", type=int,
+                      help="""Timeout in seconds""")
 
     (options, args) = parser.parse_args()
 
-    if len(args) == 0:
-        print("A program to run must be provided. Use -h for help")
+    if (len(args) == 0) and not options.pid:
+        print("A program to run or a pid must be provided. Use -h for help")
         sys.exit(1)
 
     print("{1}: Sampling memory every {0.interval}s".format(
@@ -218,30 +224,36 @@ def run_action():
     mprofile_output = "mprofile_%s.dat" % suffix
 
     # .. TODO: more than one script as argument ? ..
-    if args[0].endswith('.py') and not options.nopython:
-        if not args[0].startswith("python"):
-            args.insert(0, "python")
-        if options.multiprocess:
-            # in multiprocessing mode you want to spawn a separate
-            # python process
-            options.python = False
-    if options.python:
-        print("running as a Python program...")
-        if not args[0].startswith("python"):
-            args.insert(0, "python")
-        cmd_line = get_cmd_line(args)
-        args[1:1] = ("-m", "memory_profiler", "--timestamp",
-                     "-o", mprofile_output)
-        p = subprocess.Popen(args)
+    if not options.pid:
+        if args[0].endswith('.py') and not options.nopython:
+            if not args[0].startswith("python"):
+                args.insert(0, "python")
+            if options.multiprocess:
+                # in multiprocessing mode you want to spawn a separate
+                # python process
+                options.python = False
+        if options.python:
+            print("running as a Python program...")
+            if not args[0].startswith("python"):
+                args.insert(0, "python")
+            cmd_line = get_cmd_line(args)
+            args[1:1] = ("-m", "memory_profiler", "--timestamp",
+                         "-o", mprofile_output)
+            p = subprocess.Popen(args)
+        else:
+            cmd_line = get_cmd_line(args)
+            p = subprocess.Popen(args)
     else:
-        cmd_line = get_cmd_line(args)
-        p = subprocess.Popen(args)
+        p = int(args[0])
 
     with open(mprofile_output, "a") as f:
-        f.write("CMDLINE {0}\n".format(cmd_line))
+        if not options.pid:
+            f.write("CMDLINE {0}\n".format(cmd_line))
+
         mp.memory_usage(proc=p, interval=options.interval, timestamps=True,
                         include_children=options.include_children,
-                        multiprocess=options.multiprocess, stream=f)
+                        multiprocess=options.multiprocess, stream=f,
+                        timeout=options.timeout)
 
 
 def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
@@ -291,61 +303,6 @@ def add_brackets(xloc, yloc, xshift=0, color="r", label=None, options=None):
         ## pl.plot(xloc[1], yloc[1], ">"+color, markersize=7)
 
 
-def read_mprofile_file(filename):
-    """Read an mprofile file and return its content.
-
-    Returns
-    =======
-    content: dict
-        Keys:
-
-        - "mem_usage": (list) memory usage values, in MiB
-        - "timestamp": (list) time instant for each memory usage value, in
-            second
-        - "func_timestamp": (dict) for each function, timestamps and memory
-            usage upon entering and exiting.
-        - 'cmd_line': (str) command-line ran for this profile.
-    """
-    func_ts = {}
-    mem_usage = []
-    timestamp = []
-    children  = defaultdict(list)
-    cmd_line = None
-    f = open(filename, "r")
-    for l in f:
-        if l == '\n':
-            raise ValueError('Sampling time was too short')
-        field, value = l.split(' ', 1)
-        if field == "MEM":
-            # mem, timestamp
-            values = value.split(' ')
-            mem_usage.append(float(values[0]))
-            timestamp.append(float(values[1]))
-
-        elif field == "FUNC":
-            values = value.split(' ')
-            f_name, mem_start, start, mem_end, end = values[:5]
-            ts = func_ts.get(f_name, [])
-            ts.append([float(start), float(end),
-                       float(mem_start), float(mem_end)])
-            func_ts[f_name] = ts
-
-        elif field == "CHLD":
-            values = value.split(' ')
-            chldnum = values[0]
-            children[chldnum].append(
-                (float(values[1]), float(values[2]))
-            )
-
-        elif field == "CMDLINE":
-            cmd_line = value
-        else:
-            pass
-    f.close()
-
-    return {"mem_usage": mem_usage, "timestamp": timestamp,
-            "func_timestamp": func_ts, 'filename': filename,
-            'cmd_line': cmd_line, 'children': children}
 
 
 def plot_file(filename, index=0, timestamps=True, children=True, options=None):
@@ -355,7 +312,7 @@ def plot_file(filename, index=0, timestamps=True, children=True, options=None):
         print("matplotlib is needed for plotting.")
         sys.exit(1)
     import numpy as np  # pylab requires numpy anyway
-    mprofile = read_mprofile_file(filename)
+    mprofile = mp.read_mprofile_file(filename)
 
     if len(mprofile['timestamp']) == 0:
         print('** No memory usage values have been found in the profile '
@@ -413,7 +370,8 @@ def plot_file(filename, index=0, timestamps=True, children=True, options=None):
             cmem = np.asarray([item[0] for item in data])
 
             # Plot the line to the figure
-            pl.plot(cts, cmem, "+-"  + mem_line_colors[idx+1 % len(mem_line_colors)],
+            print (idx+1) % len(mem_line_colors)
+            pl.plot(cts, cmem, "+-"  + mem_line_colors[(idx+1) % len(mem_line_colors)],
                      label="child {}".format(proc))
 
             # Detect the maximal child memory point


### PR DESCRIPTION
This pull request is an extension to #118 and #134 and tries to improve the ability to analyze child process memory consumption. 

Changes/additions:

* track child processes by `pid` instead of sequentially -- this is to ensure that we can properly track children of processes where the parent might continuously spawn many short-lived children 
* add a `convert_mem_usage_to_df` function which produces a `pandas.DataFrame` from a list returned by `memory_usage` for easier plotting and slicing
* add the ability of `mprof` to monitor an existing process by providing a pid

Side-effects: 

* move the `read_mprofile_file` function to `memory_profiler` so that it can be used programatically
* add a `read_mprofile_file_multiprocess` function that reads a mprofile file and returns a list of timings identical to what you expect from `memory_usage`
* fix #139 
* fix bug in `plot_file` where plotting would fail when number of children > 6
* add a `timeout` flag to `mprof`