### PR TITLE
Add handling of asyncio coroutines.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-import memory_profiler
+import sys
 from distutils.core import setup
-import setuptools
+
+import memory_profiler
 
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable
@@ -31,6 +32,6 @@ setup(
     py_modules=['memory_profiler'],
     scripts=['mprof'],
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
-    license='BSD'
-
+    license='BSD',
+    install_requires=['asyncio>=3.4.3'] if sys.version_info < (3, 4) else [],
 )


### PR DESCRIPTION
Hi.
This patch works for current versions of python,  but breaks <3.3 where `yield from` is a syntax error and returning from generatior is not allowed.
I will just leave it here in case somebody would want to use this project in async world.
By now I don't see an easy way to deal with the situation except that making a dependency from tornado in 2.7 (and maybe 2.6) and use their machinery for coroutines. But by now I doubt it's worth spending a time on it 🤗
Fixes #161 